### PR TITLE
Adjust model sensitivity levels

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ const ROBOFLOW_SETTINGS = {
                                     // or train your own at https://app.roboflow.com
     version: 5, // use the version of your model with the best results
 
-    threshold: 0.9, // adjust the confidence threshold upwards if you're getting false positives, downwards if it's missing predictions
+    threshold: 0.6, // adjust the confidence threshold upwards if you're getting false positives, downwards if it's missing predictions
     overlap: 0.5 // how much predictions can overlap each other; not too important here since we combine nearby predictions into a single marker
 };
 

--- a/src/renderMap.js
+++ b/src/renderMap.js
@@ -7,7 +7,7 @@ const CONFIG = {
     MIN_SEPARATION_OF_DETECTIONS_IN_METERS: 20,
 
     // wait until a detection is made on this number of distinct frames before showing the marker
-    MIN_DETECTIONS_TO_MAKE_VISIBLE: 2
+    MIN_DETECTIONS_TO_MAKE_VISIBLE: 3
 }
 
 // Dependency for map rendering


### PR DESCRIPTION
# Description

I had tuned things to be too strict; these settings seem to detect more "weird" panels (eg the ones that are in a field with strong sun reflections vs ones on rooftops) without adding too many (any?) false positives.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Locally