### PR TITLE
Fix Links (roboflow-ai -> roboflow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://user-images.githubusercontent.com/870796/189461690-122f4e64-a66e-40f0-ac
 
 ## Try It in Your Browser
 
-The project is [deployed to Github Pages here](https://roboflow-ai.github.io/dji-aerial-georeferencing/) and you can test it out with [this sample video and flight log](https://drive.google.com/drive/folders/1m0lmYyLEQJiaykf821rYtyRvlO5Q_SAf).
+The project is [deployed to Github Pages here](https://roboflow.github.io/dji-aerial-georeferencing/) and you can test it out with [this sample video and flight log](https://drive.google.com/drive/folders/1m0lmYyLEQJiaykf821rYtyRvlO5Q_SAf).
 
 If you have your own Drone video you'd like to use, [follow the instructions in the blog post to pull your detailed flight log from Airdata](https://blog.roboflow.com/georeferencing-drone-videos/).
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/roboflow-ai/dji-aerial-georeferencing.git"
+        "url": "git+https://github.com/roboflow/dji-aerial-georeferencing.git"
     },
     "keywords": [
         "computer",
@@ -25,9 +25,9 @@
     "author": "Roboflow",
     "license": "Apache-2.0",
     "bugs": {
-        "url": "https://github.com/roboflow-ai/dji-aerial-georeferencing/issues"
+        "url": "https://github.com/roboflow/dji-aerial-georeferencing/issues"
     },
-    "homepage": "https://github.com/roboflow-ai/dji-aerial-georeferencing#readme",
+    "homepage": "https://github.com/roboflow/dji-aerial-georeferencing#readme",
     "devDependencies": {
         "autoprefixer": "^10.4.8",
         "clean-webpack-plugin": "^3.0.0",

--- a/src/index.html
+++ b/src/index.html
@@ -9,17 +9,17 @@
     <!-- <meta name="twitter:image:src" content="https://repository-images.githubusercontent.com/401149099/c7243aad-c3b6-4299-a1d2-e3039fd55994" /> -->
     <meta name="twitter:site" content="@github" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="roboflow-ai/dji-aerial-georeferencing" />
+    <meta name="twitter:title" content="roboflow/dji-aerial-georeferencing" />
     <meta name="twitter:description" content="A computer vision powered aerial imagery app powered by Roboflow." />
     <!-- <meta property="og:image" content="https://repository-images.githubusercontent.com/401149099/c7243aad-c3b6-4299-a1d2-e3039fd55994" /> -->
     <meta property="og:image:alt" content="A computer vision powered aerial imagery app powered by Roboflow." />
     <meta property="og:site_name" content="GitHub Pages" />
     <meta property="og:type" content="object" />
-    <meta property="og:title" content="roboflow-ai/dji-aerial-georeferencing" />
-    <meta property="og:url" content="https://github.com/roboflow-ai/dji-aerial-georeferencing" />
+    <meta property="og:title" content="roboflow/dji-aerial-georeferencing" />
+    <meta property="og:url" content="https://github.com/roboflow/dji-aerial-georeferencing" />
     <meta property="og:description" content="A computer vision powered aerial imagery app powered by Roboflow." />
 
-    <script src="https://cdn.roboflow.com/0.2.21/roboflow.js"></script>
+    <script src="https://cdn.roboflow.com/0.2.26/roboflow.js"></script>
 
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no">
 


### PR DESCRIPTION
# Description

When we updated our Github link from `roboflow-ai` to `roboflow` it changed the Github Pages link for this repo.

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Docs update

## Any specific deployment considerations

No

## Docs

-  Not needed
